### PR TITLE
Add MPS support

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -36,6 +36,10 @@ def run_folder(model, args, config, device, verbose=False):
 
     first_chunk_time = None
 
+    num_overlap = config.inference.num_overlap
+    if args.num_overlap is not None:
+        num_overlap = args.num_overlap
+
     for track_number, path in enumerate(all_mixtures_path, 1):
         print(f"\nProcessing track {track_number}/{total_tracks}: {os.path.basename(path)}")
 
@@ -49,13 +53,14 @@ def run_folder(model, args, config, device, verbose=False):
 
         if first_chunk_time is not None:
             total_length = mixture.shape[1]
-            num_chunks = (total_length + config.inference.chunk_size // config.inference.num_overlap - 1) // (config.inference.chunk_size // config.inference.num_overlap)
+
+            num_chunks = (total_length + config.inference.chunk_size // num_overlap - 1) // (config.inference.chunk_size // num_overlap)
             estimated_total_time = first_chunk_time * num_chunks
             print(f"Estimated total processing time for this track: {estimated_total_time:.2f} seconds")
             sys.stdout.write(f"Estimated time remaining: {estimated_total_time:.2f} seconds\r")
             sys.stdout.flush()
 
-        res, first_chunk_time = demix_track(config, model, mixture, device, first_chunk_time)
+        res, first_chunk_time = demix_track(config, model, mixture, device, num_overlap, first_chunk_time)
 
         for instr in instruments:
             vocals_output = res[instr].T
@@ -87,6 +92,7 @@ def proc_folder(args):
     parser.add_argument("--input_folder", type=str, help="folder with songs to process")
     parser.add_argument("--store_dir", default="", type=str, help="path to store model outputs")
     parser.add_argument("--device_ids", nargs='+', type=int, default=0, help='list of gpu ids')
+    parser.add_argument("--num_overlap", type=int, default=None, help='Number of overlapping chunks')
     if args is None:
         args = parser.parse_args()
     else:

--- a/inference.py
+++ b/inference.py
@@ -112,6 +112,10 @@ def proc_folder(args):
         else:
             device = torch.device(f'cuda:{device_ids[0]}')
             model = nn.DataParallel(model, device_ids=device_ids).to(device)
+    elif torch.mps.is_available():
+        print('Using MPS')
+        device = 'mps'
+        model = nn.DataParallel(model).to(device)
     else:
         device = 'cpu'
         print('CUDA is not available. Run inference on CPU. It will be very slow...')

--- a/models/mel_band_roformer/mel_band_roformer.py
+++ b/models/mel_band_roformer/mel_band_roformer.py
@@ -491,8 +491,17 @@ class MelBandRoformer(Module):
 
         scatter_indices = repeat(self.freq_indices, 'f -> b n f t', b=batch, n=num_stems, t=stft_repr.shape[-1])
 
-        stft_repr_expanded_stems = repeat(stft_repr, 'b 1 ... -> b n ...', n=num_stems)
-        masks_summed = torch.zeros_like(stft_repr_expanded_stems).scatter_add_(2, scatter_indices, masks)
+        stft_repr_expanded_stems = repeat(stft_repr, 'b 1 ... -> b n ...', n=num_stems)       
+        masks_real = masks.real
+        masks_imag = masks.imag
+
+        stft_repr_real = stft_repr_expanded_stems.real
+        stft_repr_imag = stft_repr_expanded_stems.imag
+
+        masks_summed_real = torch.zeros_like(stft_repr_real).scatter_add_(2, scatter_indices, masks_real)
+        masks_summed_imag = torch.zeros_like(stft_repr_imag).scatter_add_(2, scatter_indices, masks_imag)
+
+        masks_summed = torch.complex(masks_summed_real, masks_summed_imag)
 
         denom = repeat(self.num_bands_per_freq, 'f -> (f r) 1', r=channels)
 

--- a/utils.py
+++ b/utils.py
@@ -26,9 +26,9 @@ def get_windowing_array(window_size, fade_size, device):
     window[:fade_size] *= fadein
     return window.to(device)
 
-def demix_track(config, model, mix, device, first_chunk_time=None):
+def demix_track(config, model, mix, device, num_overlap, first_chunk_time=None):
     C = config.inference.chunk_size
-    N = config.inference.num_overlap
+    N = num_overlap
     step = C // N
     fade_size = C // 10
     border = C - step


### PR DESCRIPTION
This PR adds support for apple silicon. `torch.scatter` wasn't supported with imaginary numbers on MPS, so I changed that according to a chatgpt suggestion (sorry, I'm not much of a python/pytorch developer), and can confirm that it works on my machine. Let me know if there's anything else you'd like to see here.